### PR TITLE
Add support for Typing in samplers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.pytype
 
 # Translations
 *.mo

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name="tensorflow_similarity_alpha",
       license='Apache License 2.0',
       install_requires=[
           'numpy', 'tabulate', 'nmslib', 'tensorflow>=2.2.0', 'tqdm',
-          'matplotlib', 'pyarrow', 'pytype'
+          'matplotlib', 'pyarrow'
       ],
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/tensorflow_similarity/samplers/memory_samplers.py
+++ b/tensorflow_similarity/samplers/memory_samplers.py
@@ -1,19 +1,20 @@
+from collections import defaultdict
+import random
 from typing import Optional, Tuple
 
-import random
 import tensorflow as tf
-from tensorflow.types.experimental import TensorLike
+from tensorflow.types import experimental as tf_types
+from .samplers import Augmenter
+from .samplers import Sampler
+from .samplers import Scheduler
 from tqdm.auto import tqdm
-from collections import defaultdict
-
-from .samplers import Sampler, Augmenter, Scheduler
 
 
 class MultiShotMemorySampler(Sampler):
 
     def __init__(self,
-                 x: TensorLike,
-                 y: TensorLike,
+                 x: tf_types.TensorLike,
+                 y: tf_types.TensorLike,
                  class_per_batch: int,
                  batch_size: int = 32,
                  batch_per_epoch: int = 1000,
@@ -45,7 +46,8 @@ class MultiShotMemorySampler(Sampler):
     def get_examples(self,
                      batch_id: int,
                      num_classes: int,
-                     example_per_class: int) -> Tuple[TensorLike, TensorLike]:
+                     example_per_class: int
+                     ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
         _ = batch_id
 
         # select class at ramdom
@@ -66,7 +68,7 @@ class MultiShotMemorySampler(Sampler):
 
 class SingleShotMemorySampler(Sampler):
     def __init__(self,
-                 x: TensorLike,
+                 x: tf_types.TensorLike,
                  augmenter: Augmenter,
                  class_per_batch: int,
                  batch_size: int = 32,
@@ -85,7 +87,8 @@ class SingleShotMemorySampler(Sampler):
     def get_examples(self,
                      batch_id: int,
                      num_classes: int,
-                     example_per_class: int) -> Tuple[TensorLike, TensorLike]:
+                     example_per_class: int
+                     ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
         _ = batch_id
         _ = example_per_class
 

--- a/tensorflow_similarity/samplers/samplers.py
+++ b/tensorflow_similarity/samplers/samplers.py
@@ -1,9 +1,9 @@
+import abc
+import math
 from typing import Any, Callable, Optional, Tuple
 
-import math
 from tensorflow.keras.utils import Sequence
-from tensorflow.types.experimental import TensorLike
-from abc import abstractmethod
+from tensorflow.types import experimental as tf_types
 
 # An Augmenter is a Map TensorLike -> TensorLike. The function must
 # implement the following signature:
@@ -15,14 +15,14 @@ from abc import abstractmethod
 #   is_warmup: If True, the sampler is still in warmup phase.
 # Returns:
 #   A Tuple containing the transformed x and y tensors.
-Augmenter = (Callable[[TensorLike, TensorLike, int, bool],
-                      Tuple[TensorLike, TensorLike]])
+Augmenter = (Callable[[tf_types.TensorLike, tf_types.TensorLike, int, bool],
+                      Tuple[tf_types.TensorLike, tf_types.TensorLike]])
 
 # Not currently used.
 Scheduler = Callable[[Any], Any]
 
 
-class Sampler(Sequence):
+class Sampler(Sequence, metaclass=abc.ABCMeta):
 
     def __init__(self,
                  class_per_batch: int,
@@ -42,11 +42,12 @@ class Sampler(Sequence):
         self.is_warmup = True if warmup else False
         print("Warmup:%s" % self.is_warmup)
 
-    @abstractmethod
+    @abc.abstractmethod
     def get_examples(self,
                      batch_id: int,
                      num_classes: int,
-                     example_per_class: int) -> Tuple[TensorLike, TensorLike]:
+                     example_per_class: int
+                     ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
         """Get the set of examples that would be used to create a single batch.
 
         Notes:
@@ -79,10 +80,15 @@ class Sampler(Sequence):
             print("Warmup complete")
             self.is_warmup = False
 
-    def __getitem__(self, batch_id: int) -> Tuple[TensorLike, TensorLike]:
+    def __getitem__(self,
+                    batch_id: int
+                    ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
+
         return self.generate_batch(batch_id)
 
-    def generate_batch(self, batch_id: int) -> Tuple[TensorLike, TensorLike]:
+    def generate_batch(self,
+                       batch_id: int
+                       ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
 
         example_per_class = math.ceil(self.batch_size / self.class_per_batch)
         # ! can't have less than 2 example per class in a batch

--- a/tensorflow_similarity/samplers/utils.py
+++ b/tensorflow_similarity/samplers/utils.py
@@ -1,22 +1,26 @@
-import random
-import tensorflow as tf
-from tqdm.auto import tqdm
-from tensorflow.keras.utils import Sequence
 from collections import defaultdict
+import random
+from typing import Sequence, Tuple
+
+import tensorflow as tf
+from tensorflow.types import experimental as tf_types
 
 
-def select_examples(x, y, class_list, num_example_per_class):
+def select_examples(x: tf_types.TensorLike,
+                    y: tf_types.TensorLike,
+                    class_list: Sequence[int],
+                    num_example_per_class: int
+                    ) -> Tuple[tf_types.TensorLike, tf_types.TensorLike]:
     """Randomly select at most N examples per class
 
     Args:
-        x (Tensor): data
-        y (Tensor): labels
-        class_list (list(int)): list of class to sample from.
-        num_example_per_class (int): num of examples to select from EACH class.
+        x: A 2-D Tensor containing the data.
+        y: A 1-D Tensor containing the labels.
+        class_list: list of class to sample from.
+        num_example_per_class: num of examples to select from EACH class.
 
     Returns:
-        (list): x, y
-
+        A Tuple containing the subset of x and y.
     """
 
     # Mapping class to idx
@@ -30,8 +34,7 @@ def select_examples(x, y, class_list, num_example_per_class):
     idxs = []
     for class_id in class_list:
         class_idxs = index_per_class[class_id]
-        random.shuffle(class_idxs)
-        idxs.extend(class_idxs[:num_example_per_class])
+        idxs.extend(random.sample(class_idxs, num_example_per_class))
 
     random.shuffle(idxs)
     batch_x = tf.gather(x, idxs)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 flake8
 twine
 perfCounters
+pytype


### PR DESCRIPTION
Simple PR as first contribution.

**Typing**
- Add Type Alias for Augmenter and Scheduler to help clarify func signature.
- Add types for all methods in samplers.py and memory_samplers.py

**Small Changes**
- Replace random.shuffle with random.sample to improve performance. See https://docs.python.org/3/library/random.html#random.sample
- Replace '//' with '/' in Sampler.generate_batch() when computing the example_per_class. The '//' is integer divide in py3. This will prevent math.ceil from rounding up and can lead to batches < batch_size.