### PR TITLE
Remove the alpha from tensorflow similarity before importing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,4 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
-    package_dir={"": "tensorflow_similarity"},
-    packages=find_packages(where="tensorflow_similarity")
-    )
+    packages=find_packages())


### PR DESCRIPTION
Not implying it's out of alpha - but getting the tooling right is much easier without the package name discrepancy.