### PR TITLE
Use assertAllClose to replace assertion in test_distances.py and test_distance_metrics.py

### DIFF
--- a/tests/test_distance_metrics.py
+++ b/tests/test_distance_metrics.py
@@ -3,6 +3,7 @@ from tensorflow_similarity.distance_metrics import DistanceMetric
 from tensorflow_similarity.distance_metrics import DistanceGapMetric
 from tensorflow_similarity.distances import CosineDistance
 from tensorflow_similarity.types import FloatTensor
+
 EMB1 = [
     [0.5, 1, 0.5],
     [0.2, 0.8, 0.4],
@@ -25,7 +26,7 @@ def cosine(a: FloatTensor, b: FloatTensor, axis: int = -1) -> FloatTensor:
 
 
 def compute_metric(distance, aggregate, labels, embeddings):
-    "Inner function that call the core class"
+    'Inner function that call the core class'
     metric = DistanceMetric(distance, aggregate=aggregate)
     metric.update_state(labels, embeddings, None)
     return metric.result()
@@ -49,53 +50,52 @@ def test_distance_metric_serialize():
     assert metric.result() == metric2.result()
 
 
-def test_avg_positive():
+class DistanceMetricsTest(tf.test.TestCase):
 
-    agg = ['avg', tf.reduce_mean]
+    def test_avg_positive(self):
 
-    # metric computation
-    metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
+        agg = ['avg', tf.reduce_mean]
 
-    # manual computation
-    hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
-    manual_val = agg[1](hard_distances)
-    assert metric_val == manual_val
+        # metric computation
+        metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
 
+        # manual computation
+        hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
+        manual_val = agg[1](hard_distances)
+        self.assertAllClose(metric_val, manual_val)
 
-def test_sum_positive():
-    agg = ['sum', tf.reduce_sum]
+    def test_sum_positive(self):
+        agg = ['sum', tf.reduce_sum]
 
-    # metric computation
-    metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
+        # metric computation
+        metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
 
-    # manual computation
-    hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
-    manual_val = agg[1](hard_distances)
-    assert metric_val == manual_val
+        # manual computation
+        hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
+        manual_val = agg[1](hard_distances)
+        self.assertAllClose(metric_val, manual_val)
 
+    def test_max_positive(self):
+        agg = ['max', tf.reduce_max]
 
-def test_max_positive():
-    agg = ['max', tf.reduce_max]
+        # metric computation
+        metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
 
-    # metric computation
-    metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
+        # manual computation
+        hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
+        manual_val = agg[1](hard_distances)
+        self.assertAllClose(metric_val, manual_val)
 
-    # manual computation
-    hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
-    manual_val = agg[1](hard_distances)
-    assert metric_val == manual_val
+    def test_min_positive(self):
+        agg = ['min', tf.reduce_min]
 
+        # metric computation
+        metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
 
-def test_min_positive():
-    agg = ['min', tf.reduce_min]
-
-    # metric computation
-    metric_val = compute_metric('cosine', agg[0], LABELS, EMBEDDINGS)
-
-    # manual computation
-    hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
-    manual_val = agg[1](hard_distances)
-    assert metric_val == manual_val
+        # manual computation
+        hard_distances = manual_hard_mining(cosine, EMB1, EMB2)
+        manual_val = agg[1](hard_distances)
+        self.assertAllClose(metric_val, manual_val)
 
 
 def test_gap():

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -59,8 +59,13 @@ def test_euclidean_same():
     assert tf.round(tf.reduce_sum(vals)) == 0
 
 
-def test_euclidean_opposite():
-    a = tf.convert_to_tensor([[0.0, 1.0], [0.0, -1.0]])
-    d = EuclidianDistance()
-    vals = d(a)
-    assert tf.reduce_all(tf.math.equal(vals, tf.constant([[1e-8, 2.0],[2.0, 1e-8]])))
+class DistancesTest(tf.test.TestCase):
+
+    def test_euclidean_opposite(self):
+        a = tf.convert_to_tensor([[0.0, 1.0], [0.0, -1.0]])
+        d = EuclidianDistance()
+        vals = d(a)
+        self.assertAllClose(
+            vals,
+            tf.constant([[1e-8, 2.0], [2.0, 1e-8]]),
+        )


### PR DESCRIPTION
This makes those tests robust otherwise float number precision may cause tests fail.
This fixes failing tests in google3 imported tf.similarity library.
