### PR TITLE
Raise errors if users try to evaluate over an empty index or pass an …

### DIFF
--- a/tensorflow_similarity/evaluators/memory_evaluator.py
+++ b/tensorflow_similarity/evaluators/memory_evaluator.py
@@ -216,8 +216,13 @@ class MemoryEvaluator(Evaluator):
             verbose: Be verbose. Defaults to 1.
         Returns:
             CalibrationResults containing the thresholds and cutpoints Dicts.
+
+        Raises:
+            ValueError: lookupds must not be empty.
         """
         # TODO (ovallis): Assert if index is empty, or if the lookup is empty.
+        if len(lookups) == 0:
+            raise ValueError("lookups must not be empty.")
 
         # making a single list of metrics
         # Need expl covariance problem

--- a/tensorflow_similarity/evaluators/memory_evaluator.py
+++ b/tensorflow_similarity/evaluators/memory_evaluator.py
@@ -222,7 +222,8 @@ class MemoryEvaluator(Evaluator):
         """
         # TODO (ovallis): Assert if index is empty, or if the lookup is empty.
         if len(lookups) == 0:
-            raise ValueError("lookups must not be empty.")
+            raise ValueError("lookups must not be empty. Is there no data in "
+                             "the index?")
 
         # making a single list of metrics
         # Need expl covariance problem

--- a/tensorflow_similarity/models/similarity_model.py
+++ b/tensorflow_similarity/models/similarity_model.py
@@ -588,7 +588,7 @@ class SimilarityModel(tf.keras.Model):
         """
         if self._index.size() == 0:
             raise IndexError("Index must contain embeddings but is "
-                             "currently empty.")
+                             "currently empty. Have you run model.index()?")
 
         # get embeddings
         if verbose:
@@ -658,7 +658,7 @@ class SimilarityModel(tf.keras.Model):
         # solution to keep the end-user API clean and doing inferences once.
         if self._index.size() == 0:
             raise IndexError("Index must contain embeddings but is "
-                             "currently empty.")
+                             "currently empty. Have you run model.index()?")
 
         if not self._index.is_calibrated:
             raise ValueError("Uncalibrated model: run model.calibration()")

--- a/tensorflow_similarity/models/similarity_model.py
+++ b/tensorflow_similarity/models/similarity_model.py
@@ -582,7 +582,14 @@ class SimilarityModel(tf.keras.Model):
         Returns:
             Dictionary of metric results where keys are the metric names and
             values are the metrics values.
+
+        Raises:
+            IndexError: Index must contain embeddings but is currently empty.
         """
+        if self._index.size() == 0:
+            raise IndexError("Index must contain embeddings but is "
+                             "currently empty.")
+
         # get embeddings
         if verbose:
             print("|-Computing embeddings")
@@ -642,12 +649,20 @@ class SimilarityModel(tf.keras.Model):
 
         Returns:
             Dictionary of (distance_metrics.md)[evaluation metrics]
+
+        Raises:
+            IndexError: Index must contain embeddings but is currently empty.
+            ValueError: Uncalibrated model: run model.calibration()")
         """
         # There is some code duplication in this function but that is the best
         # solution to keep the end-user API clean and doing inferences once.
+        if self._index.size() == 0:
+            raise IndexError("Index must contain embeddings but is "
+                             "currently empty.")
 
         if not self._index.is_calibrated:
             raise ValueError("Uncalibrated model: run model.calibration()")
+
         cal_metric = self._index.get_calibration_metric()
 
         # get embeddings


### PR DESCRIPTION
…empty set of lookupd to the evaluators.