### PR TITLE
Added num_repeat arg to TFRecordDatasetSampler

### DIFF
--- a/tensorflow_similarity/samplers/tfrecords_samplers.py
+++ b/tensorflow_similarity/samplers/tfrecords_samplers.py
@@ -29,6 +29,7 @@ def TFRecordDatasetSampler(
     async_cycle: bool = False,
     prefetch_size: Optional[int] = None,
     shard_suffix: str = "*.tfrec",
+    num_repeat: int = -1,
 ) -> tf.data.Dataset:
     """Create a [TFRecordDataset](https://www.tensorflow.org/api_docs/python/tf/data/TFRecordDataset) based sampler.
 
@@ -87,6 +88,8 @@ def TFRecordDatasetSampler(
         shard_suffix: Glog pattern used to collect the shard files list.
         Defaults to "*.tfrec".
 
+        num_repeat: How many times to repeat the dataset. Defaults to -1 (infinite).
+
     Returns:
         A `TF.data.dataset` ready to be consumed by the model.
     """
@@ -127,7 +130,7 @@ def TFRecordDatasetSampler(
             deterministic=False,
         )
         ds = ds.map(deserialization_fn, num_parallel_calls=parallelism)
-        ds = ds.repeat()
+        ds = ds.repeat(count=num_repeat)
         ds = ds.batch(batch_size)
         ds = ds.prefetch(prefetch_size)
         return ds


### PR DESCRIPTION
This PR is a suggested implementation for https://github.com/tensorflow/similarity/issues/194.

If the value is `-1`, TFDatasets returns the dataset as an infinite loop. 
`None` (current implementation) is equal to `-1`, please see https://github.com/tensorflow/tensorflow/blob/v2.7.0/tensorflow/python/data/ops/dataset_ops.py#L1366 for details.