### PR TITLE
Add WarmUpCosine learning rate schedule. 

### DIFF
--- a/tensorflow_similarity/__init__.py
+++ b/tensorflow_similarity/__init__.py
@@ -34,3 +34,4 @@ from . import training_metrics  # noqa
 from . import types  # noqa
 from . import utils  # noqa
 from . import visualization  # noqa
+from . import learning_rate_schedule as schedules # noqa

--- a/tensorflow_similarity/learning_rate_schedule.py
+++ b/tensorflow_similarity/learning_rate_schedule.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from tensorflow_similarity.types import FloatTensor
 
 
+@tf.keras.utils.register_keras_serializable(package="Similarity")
 class WarmUpCosine(tf.keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses a cosine decay schedule with a warmup period.
 

--- a/tensorflow_similarity/learning_rate_schedule.py
+++ b/tensorflow_similarity/learning_rate_schedule.py
@@ -1,0 +1,104 @@
+from typing import Any, Dict
+
+import tensorflow as tf
+
+from tensorflow_similarity.types import FloatTensor
+
+
+class WarmUpCosine(tf.keras.optimizers.schedules.LearningRateSchedule):
+    """A LearningRateSchedule that uses a cosine decay schedule with a warmup period.
+
+    This learning rate schedule is useful for training when using the Barlow Twin Loss.
+
+    The warmup period applies a linear scaling to the CosineDecay schedule.
+    """
+
+    def __init__(
+        self,
+        initial_learning_rate: float,
+        decay_steps: int,
+        warmup_steps: int,
+        warmup_learning_rate: float = 0.0,
+        alpha: float = 0.0,
+        name: str = "WarmUpCosine",
+    ):
+        """Applies cosine decay to the learning rate.
+
+        Args:
+          initial_learning_rate: A scalar `float32` or `float64` Tensor or a
+            Python number. The initial learning rate.
+          decay_steps: A scalar `int32` or `int64` `Tensor` or a Python number.
+            Number of steps to decay over.
+          warmup_steps: A scalar `int32` or `int64` `Tensor` or a Python number.
+            Number of steps to warmup over. Must be smaller than the number of
+            decay_steps.
+          warmup_learning_rate: A scalar `float32` or `float64` Tensor or a
+            Python number. The initial warmup learning rate. Must be smaller than
+            the initial_learning_rate. Defaults to 0.0.
+          alpha: A scalar `float32` or `float64` Tensor or a Python number.
+            Minimum learning rate value as a fraction of initial_learning_rate.
+            Defaults to 0.0.
+          name: String. Optional name of the operation. Defaults to 'WarmUpCosine'.
+        """
+
+        super().__init__()
+
+        if warmup_learning_rate > initial_learning_rate:
+            raise ValueError(
+                "warmup_learning_rate must be smaller than the initial_learning_rate"
+            )
+
+        if warmup_steps > decay_steps:
+            raise ValueError(
+                "warmup_steps must be smaller than the decay_steps"
+            )
+        self.initial_learning_rate = initial_learning_rate
+        self.decay_steps = decay_steps
+        self.alpha = alpha
+        self.warmup_learning_rate = warmup_learning_rate
+        self.warmup_steps = warmup_steps
+        self.name = name
+
+        self.cosine_decay = tf.keras.optimizers.schedules.CosineDecay(
+            initial_learning_rate=initial_learning_rate,
+            decay_steps=decay_steps,
+            alpha=alpha,
+        )
+        # Compute the warmup increment.
+        self.tf_initial_learning_rate = tf.convert_to_tensor(
+            self.initial_learning_rate, name="initial_learning_rate"
+        )
+        self.dtype = self.tf_initial_learning_rate.dtype
+        self.learning_rate_delta = tf.convert_to_tensor(
+            self.warmup_learning_rate / self.initial_learning_rate, self.dtype
+        )
+        self.warmup_inc = tf.math.divide_no_nan(
+            (1.0 - self.learning_rate_delta),
+            tf.convert_to_tensor(self.warmup_steps, self.dtype),
+        )
+
+        # If the warmup increment is zero we have no warm up phase and we set
+        # the learning rate delta to 1.0 to ensure the warmup_scaler value is
+        # always fixed at 1.0.
+        if self.warmup_inc == 0:
+            self.learning_rate_delta = tf.constant([1.0], self.dtype)
+
+    def __call__(self, step: FloatTensor) -> FloatTensor:
+        global_step_recomp = tf.convert_to_tensor(step, self.dtype)
+        warmup_scaler = tf.minimum(
+            1.0, self.warmup_inc * global_step_recomp + self.learning_rate_delta
+        )
+        learning_rate: FloatTensor = (
+            self.cosine_decay(global_step_recomp) * warmup_scaler
+        )
+        return learning_rate
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "initial_learning_rate": self.initial_learning_rate,
+            "decay_steps": self.decay_steps,
+            "alpha": self.alpha,
+            "warmup_learning_rate": self.warmup_learning_rate,
+            "warmup_steps": self.warmup_steps,
+            "name": self.name,
+        }

--- a/tests/test_learning_rate_schedule.py
+++ b/tests/test_learning_rate_schedule.py
@@ -1,0 +1,122 @@
+from unittest import TestCase
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from tensorflow_similarity.learning_rate_schedule import WarmUpCosine
+
+testdata = [
+    range(10),
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9],
+    np.arange(10),
+    tf.range(10, dtype="float32"),
+]
+
+test_ids = ["python range", "python list", "numpy arange", "tf range"]
+
+
+@pytest.mark.parametrize("steps", testdata, ids=test_ids)
+def test_warmup_cosine(steps):
+    warmup_cosine = WarmUpCosine(
+        initial_learning_rate=1.0,
+        decay_steps=10,
+        warmup_steps=2,
+        warmup_learning_rate=0.5,
+        alpha=0.1,
+        name="foo",
+    )
+
+    lrs = warmup_cosine(steps)
+
+    expected_lrs = tf.constant(
+        [
+            0.5,
+            0.7334816,
+            0.9140576,
+            0.8145034,
+            0.68905765,
+            0.54999995,
+            0.41094226,
+            0.28549662,
+            0.18594232,
+            0.12202458,
+        ]
+    )
+
+    np.testing.assert_allclose(expected_lrs, lrs, rtol=1e-06)
+
+
+def test_warmup_cosine_no_warmup():
+    warmup_cosine = WarmUpCosine(
+        initial_learning_rate=1.0,
+        decay_steps=10,
+        warmup_steps=0,
+        warmup_learning_rate=0.5,
+        alpha=0.1,
+        name="foo",
+    )
+
+    lrs = warmup_cosine(range(10))
+
+    expected_lrs = tf.constant(
+        [
+            1.0,
+            0.977975,
+            0.9140576,
+            0.8145034,
+            0.68905765,
+            0.54999995,
+            0.41094226,
+            0.28549662,
+            0.18594232,
+            0.12202458,
+        ]
+    )
+
+    np.testing.assert_allclose(expected_lrs, lrs, rtol=1e-06)
+
+
+def test_warmup_cosine_config():
+    warmup_cosine = WarmUpCosine(
+        initial_learning_rate=1.0,
+        decay_steps=10,
+        warmup_steps=2,
+        warmup_learning_rate=0.0,
+        alpha=0.1,
+        name="foo",
+    )
+
+    config = warmup_cosine.get_config()
+
+    expected_config = {
+        "initial_learning_rate": 1.0,
+        "decay_steps": 10,
+        "alpha": 0.1,
+        "warmup_learning_rate": 0.0,
+        "warmup_steps": 2,
+        "name": "foo",
+    }
+
+    TestCase().assertDictEqual(expected_config, config)
+
+
+def test_warmup_cosine_assert_smaller_warmup_learning_rate():
+    msg = "warmup_learning_rate must be smaller than the initial_learning_rate"
+    with pytest.raises(ValueError, match=msg):
+        _ = WarmUpCosine(
+            initial_learning_rate=1.0,
+            decay_steps=10,
+            warmup_steps=5,
+            warmup_learning_rate=1.5,
+        )
+
+
+def test_warmup_cosine_assert_smaller_warmup_steps():
+    msg = "warmup_steps must be smaller than the decay_steps"
+    with pytest.raises(ValueError, match=msg):
+        _ = WarmUpCosine(
+            initial_learning_rate=1.0,
+            decay_steps=10,
+            warmup_steps=20,
+        )


### PR DESCRIPTION
This is required for the Barlow Twins loss.