### PR TITLE
Add GeneralizeMeanPooling2D layer

### DIFF
--- a/tensorflow_similarity/layers.py
+++ b/tensorflow_similarity/layers.py
@@ -12,34 +12,247 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Specialized Similarity `keras.layers`"""
+import math
+from typing import Any, Dict, Optional
 
-
-from typing import Dict
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 from tensorflow.keras import layers
-from .types import FloatTensor
+from tensorflow.python.keras.utils import conv_utils
+from .types import FloatTensor, IntTensor
+
 
 @tf.keras.utils.register_keras_serializable(package="Similarity")
 class MetricEmbedding(Layer):
-    def __init__(self, unit: int):
-        """L2 Normalized `Dense` layer usually used as output layer.
+    def __init__(
+        self,
+        units: int,
+        activation: Optional[Any] = None,
+        use_bias: bool = True,
+        kernel_initializer: Optional[Any] = "glorot_uniform",
+        bias_initializer: Optional[Any] = "zeros",
+        kernel_regularizer: Optional[Any] = None,
+        bias_regularizer: Optional[Any] = None,
+        activity_regularizer: Optional[Any] = None,
+        kernel_constraint: Optional[Any] = None,
+        bias_constraint: Optional[Any] = None,
+        **kwargs
+    ) -> None:
+        """L2 Normalized `Dense` layer.
+
+        This layer is usually used as output layer, especially when using cosine
+        distance as the similarity metric.
 
         Args:
-            unit: Dimension of the output embbeding. Commonly between
-            32 and 512. Larger embeddings usually result in higher accuracy up
-            to a point at the expense of making search slower.
+          units: Positive integer, dimensionality of the output space.
+          activation: Activation function to use.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+          use_bias: Boolean, whether the layer uses a bias vector.
+          kernel_initializer: Initializer for the `kernel` weights matrix.
+          bias_initializer: Initializer for the bias vector.
+          kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix.
+          bias_regularizer: Regularizer function applied to the bias vector.
+          activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+          kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix.
+          bias_constraint: Constraint function applied to the bias vector.
         """
-        self.unit = unit
-        self.dense = layers.Dense(unit)
-        super().__init__()
-        # FIXME: enforce the shape
-        # self.input_spec = rank2
+        super().__init__(**kwargs)
+
+        self.units = units
+        self.activation = activation
+        self.use_bias = use_bias
+        self.kernel_initializer = kernel_initializer
+        self.bias_initializer = bias_initializer
+        self.kernel_regularizer = kernel_regularizer
+        self.bias_regularizer = bias_regularizer
+        self.activity_regularizer = activity_regularizer
+        self.kernel_constraint = kernel_constraint
+        self.bias_constraint = bias_constraint
+        self.dense = layers.Dense(
+            units,
+            activation=activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            bias_initializer=bias_initializer,
+            kernel_regularizer=kernel_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            kernel_constraint=kernel_constraint,
+            bias_constraint=bias_constraint,
+        )
+        self.input_spec = tf.keras.layers.InputSpec(min_ndim=2)
 
     def call(self, inputs: FloatTensor) -> FloatTensor:
         x = self.dense(inputs)
         normed_x: FloatTensor = tf.math.l2_normalize(x, axis=1)
         return normed_x
 
-    def get_config(self) -> Dict[str, int]:
-        return {'unit': self.unit}
+    def get_config(self) -> Dict[str, Any]:
+        config = {
+            "units": self.units,
+            "activation": self.activation,
+            "use_bias": self.use_bias,
+            "kernel_initializer": self.kernel_initializer,
+            "bias_initializer": self.bias_initializer,
+            "kernel_regularizer": self.kernel_regularizer,
+            "bias_regularizer": self.bias_regularizer,
+            "activity_regularizer": self.activity_regularizer,
+            "kernel_constraint": self.kernel_constraint,
+            "bias_constraint": self.bias_constraint,
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}
+
+
+@tf.keras.utils.register_keras_serializable(package="Similarity")
+class GeneralizedMeanPooling2D(Layer):
+    """Computes the Generalized Mean of each channel in a tensor.
+
+    $$
+    \textbf{e} = \left[\left(\frac{1}{|\Omega|}\sum_{u\in{\Omega}}x^{p}_{cu}\right)^{\frac{1}{p}}\right]_{c=1,\cdots,C}
+    $$
+
+    The Generalized Mean (GeM) provides a parameter `p` that sets an exponent
+    enabling the pooling to increase or decrease the contrast between salient
+    features in the feature map.
+
+    The pooling is equal to GlobalAveragePooling2D when `p` is 1.0 and equal
+    to MaxPool2D when `p` is `inf`.
+
+    This implementation shifts the feature map values such that the minimum
+    value is equal to 1.0, then computes the mean pooling, and finally shifts
+    the values back. This ensures that all values are positive as the
+    generalized mean is only valid over positive real values.
+
+    Args:
+      p: Set the power of the mean. A value of 1.0 is equivalent to the
+        arithmetic mean, while a value of `inf` is equivalent to MaxPool2D.
+        Note, math.inf, -math.inf, and 0.0 are all supported, as well as most
+        positive and negative values of `p`. However, large positive values for
+        `p` may lead to overflow. In practice, math.inf should be used for any
+        `p` larger than > 25.
+      data_format: One of `channels_last` (default) or `channels_first`. The
+        ordering of the dimensions in the inputs.  `channels_last`
+        corresponds to inputs with shape `(batch, steps, features)` while
+        `channels_first` corresponds to inputs with shape
+        `(batch, features, steps)`.
+      keepdims: A boolean, whether to keep the temporal dimension or not.
+        If `keepdims` is `False` (default), the rank of the tensor is reduced
+        for spatial dimensions.  If `keepdims` is `True`, the temporal
+        dimension are retained with length 1.  The behavior is the same as
+        for `tf.reduce_max` or `np.max`.
+
+    Input shape:
+      - If `data_format='channels_last'`:
+        3D tensor with shape:
+        `(batch_size, steps, features)`
+      - If `data_format='channels_first'`:
+        3D tensor with shape:
+        `(batch_size, features, steps)`
+    Output shape:
+      - If `keepdims`=False:
+        2D tensor with shape `(batch_size, features)`.
+      - If `keepdims`=True:
+        - If `data_format='channels_last'`:
+          3D tensor with shape `(batch_size, 1, features)`
+        - If `data_format='channels_first'`:
+          3D tensor with shape `(batch_size, features, 1)`
+    """
+
+    def __init__(
+        self,
+        p: float = 1.0,
+        data_format: Optional[str] = None,
+        keepdims: bool = False,
+        **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.p = p
+        self.data_format = conv_utils.normalize_data_format(data_format)
+        self.keepdims = keepdims
+        self.input_spec = tf.keras.layers.InputSpec(ndim=4)
+        self.gap = tf.keras.layers.GlobalAveragePooling2D(data_format, keepdims)
+
+        if tf.math.abs(self.p) < 0.00001:
+            self.compute_mean = self._geometric_mean
+        elif self.p == math.inf:
+            self.compute_mean = self._pos_inf
+        elif self.p == -math.inf:
+            self.compute_mean = self._neg_inf
+        else:
+            self.compute_mean = self._generalized_mean
+
+    def compute_output_shape(self, input_shape: IntTensor) -> IntTensor:
+        input_shape = tf.TensorShape(input_shape).as_list()
+        if self.data_format == "channels_last":
+            if self.keepdims:
+                return tf.TensorShape([input_shape[0], 1, 1, input_shape[3]])
+            else:
+                return tf.TensorShape([input_shape[0], input_shape[3]])
+        else:
+            if self.keepdims:
+                return tf.TensorShape([input_shape[0], input_shape[1], 1, 1])
+            else:
+                return tf.TensorShape([input_shape[0], input_shape[1]])
+
+    def call(self, inputs: FloatTensor) -> FloatTensor:
+        x = inputs
+        if self.data_format == "channels_last":
+            mins = tf.math.reduce_min(x, axis=[1, 2])
+            x_offset = x - mins[:, tf.newaxis, tf.newaxis, :] + 1
+            if self.keepdims:
+                mins = mins[:, tf.newaxis, tf.newaxis, :]
+        else:
+            mins = tf.math.reduce_min(x, axis=[2, 3])
+            x_offset = x - mins[:, :, tf.newaxis, tf.newaxis] + 1
+            if self.keepdims:
+                mins = mins[:, :, tf.newaxis, tf.newaxis]
+
+        x_offset = self.compute_mean(x_offset)
+        x = x_offset + mins - 1
+
+        return x
+
+    def _geometric_mean(self, x):
+        x = tf.math.log(x)
+        x = self.gap(x)
+        return tf.math.exp(x)
+
+    def _generalized_mean(self, x):
+        x = tf.math.pow(x, self.p)
+        x = self.gap(x)
+        return tf.math.pow(x, 1.0 / self.p)
+
+    def _pos_inf(self, x):
+        if self.data_format == "channels_last":
+            pool_size = (x.shape[1], x.shape[2])
+        else:
+            pool_size = (x.shape[2], x.shape[3])
+        print(x.shape)
+        mpl = tf.keras.layers.MaxPool2D(
+            pool_size=pool_size, data_format=self.data_format
+        )
+        x = mpl(x)
+        if not self.keepdims:
+            if self.data_format == "channels_last":
+                x = tf.reshape(x, (x.shape[0], x.shape[3]))
+            else:
+                x = tf.reshape(x, (x.shape[0], x.shape[1]))
+        return x
+
+    def _neg_inf(self, x):
+        return self._pos_inf(x * -1) * -1
+
+    def get_config(self) -> Dict[str, Any]:
+        config = {
+            "p": self.p,
+            "data_format": self.data_format,
+            "keepdims": self.keepdims,
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_similarity/layers.py
+++ b/tensorflow_similarity/layers.py
@@ -191,14 +191,18 @@ class GeneralizedMeanPooling2D(Layer):
         input_shape = tf.TensorShape(input_shape).as_list()
         if self.data_format == "channels_last":
             if self.keepdims:
-                return tf.TensorShape([input_shape[0], 1, 1, input_shape[3]])
+                w: IntTensor = tf.TensorShape([input_shape[0], 1, 1, input_shape[3]])
+                return w
             else:
-                return tf.TensorShape([input_shape[0], input_shape[3]])
+                x: IntTensor = tf.TensorShape([input_shape[0], input_shape[3]])
+                return x
         else:
             if self.keepdims:
-                return tf.TensorShape([input_shape[0], input_shape[1], 1, 1])
+                y: IntTensor = tf.TensorShape([input_shape[0], input_shape[1], 1, 1])
+                return y
             else:
-                return tf.TensorShape([input_shape[0], input_shape[1]])
+                z: IntTensor = tf.TensorShape([input_shape[0], input_shape[1]])
+                return z
 
     def call(self, inputs: FloatTensor) -> FloatTensor:
         x = inputs

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,134 @@
+import math
+from unittest import TestCase
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from tensorflow_similarity.layers import MetricEmbedding
+from tensorflow_similarity.layers import GeneralizedMeanPooling2D
+
+
+@pytest.fixture
+def input_tensor():
+    # A (1, 3, 3, 2) Tensor.
+    return tf.constant(
+        [
+            [
+                [[0.0, 5.0], [0.0, 5.0], [0.0, 5.0]],
+                [[5.0, 10.0], [5.0, 10.0], [5.0, 10.0]],
+                [[10.0, 15.0], [10.0, 15.0], [10.0, 15.0]],
+            ],
+        ]
+    )
+
+
+def test_generalized_mean_pooling(input_tensor):
+    result = GeneralizedMeanPooling2D(p=1.0)(input_tensor)
+    expected = tf.constant([[5.0, 10.0]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_inf(input_tensor):
+    result = GeneralizedMeanPooling2D(p=math.inf, keepdims=True)(input_tensor)
+    expected = tf.constant([[[[10.0, 15.0]]]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_neg_inf(input_tensor):
+    result = GeneralizedMeanPooling2D(p=-math.inf, keepdims=True)(input_tensor)
+    expected = tf.constant([[[[0.0, 5.0]]]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_zero(input_tensor):
+    result = GeneralizedMeanPooling2D(p=0.0)(input_tensor)
+    expected = tf.constant([[3.0412402, 8.041241]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_keepdims(input_tensor):
+    result = GeneralizedMeanPooling2D(p=1.0, keepdims=True)(input_tensor)
+    expected = tf.constant([[[[5.0, 10.0]]]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_channels_first(input_tensor):
+    result = GeneralizedMeanPooling2D(p=1.0, data_format="channels_first")(
+        input_tensor
+    )
+    # With channels first we expect a (1,3) shape.
+    expected = tf.constant([[2.5, 7.5, 12.5]])
+    np.testing.assert_allclose(result, expected, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_compute_shape():
+    input_shape = tf.constant([1, 2, 3, 4])
+    result = GeneralizedMeanPooling2D().compute_output_shape(input_shape)
+    expected_shape = tf.constant([1, 4])
+    np.testing.assert_allclose(result, expected_shape, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_compute_shape_keepdims():
+    input_shape = tf.constant([1, 2, 3, 4])
+    result = GeneralizedMeanPooling2D(keepdims=True).compute_output_shape(
+        input_shape
+    )
+    expected_shape = tf.constant([1, 1, 1, 4])
+    np.testing.assert_allclose(result, expected_shape, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_compute_shape_dataformat():
+    input_shape = tf.constant([1, 2, 3, 4])
+    result = GeneralizedMeanPooling2D(
+        data_format="channels_first"
+    ).compute_output_shape(input_shape)
+    expected_shape = tf.constant([1, 2])
+    np.testing.assert_allclose(result, expected_shape, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_get_config():
+    gem = GeneralizedMeanPooling2D(
+        p=3.0, data_format="channels_first", keepdims=True, name="GEM"
+    )
+    config = gem.get_config()
+    expected_config = {
+        "p": 3.0,
+        "data_format": "channels_first",
+        "keepdims": True,
+        "name": "GEM",
+        "trainable": True,
+        "dtype": "float32",
+    }
+    TestCase().assertDictEqual(expected_config, config)
+
+
+def test_metric_embedding():
+    input_tensor = tf.constant([[4.0, 4.0, 4.0, 4.0], [1.0, 1.0, 1.0, 1.0]])
+    me_layer = MetricEmbedding(
+        4, kernel_initializer=tf.constant_initializer(1.0)
+    )
+    result = me_layer(input_tensor)
+    expected_result = tf.constant([[0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]])
+    np.testing.assert_allclose(result, expected_result, rtol=1e-06)
+
+
+def test_generalized_mean_pooling_get_config():
+    me_layer = MetricEmbedding(32)
+    config = me_layer.get_config()
+    expected_config = {
+        "activation": None,
+        "activity_regularizer": None,
+        "bias_constraint": None,
+        "bias_initializer": "zeros",
+        "bias_regularizer": None,
+        "dtype": "float32",
+        "kernel_constraint": None,
+        "kernel_initializer": "glorot_uniform",
+        "kernel_regularizer": None,
+        "name": "metric_embedding_1",
+        "trainable": True,
+        "units": 32,
+        "use_bias": True,
+    }
+    TestCase().assertDictEqual(expected_config, config)


### PR DESCRIPTION
GeM adds support for global mean pooling using the generalized mean.
This enables the pooling to increase or decrease the contrast between
the feature map activation's.

Add tests for GeM and MetricEmbedding layers.