### PR TITLE
Distance and losses refactor

### DIFF
--- a/tensorflow_similarity/distances.py
+++ b/tensorflow_similarity/distances.py
@@ -256,7 +256,6 @@ class SNRDistance(Distance):
         anchor_var = tf.math.reduce_variance(query_embeddings, axis=1)
 
         # Calculating pairwise noise variances
-
         q_rs = tf.reshape(query_embeddings, shape=[tf.shape(query_embeddings)[0], -1])
         k_rs = tf.reshape(key_embeddings, shape=[tf.shape(key_embeddings)[0], -1])
         delta = tf.expand_dims(q_rs, axis=1) - tf.expand_dims(k_rs, axis=0)

--- a/tensorflow_similarity/losses/metric_loss.py
+++ b/tensorflow_similarity/losses/metric_loss.py
@@ -51,7 +51,7 @@ class MetricLoss(tf.keras.losses.Loss):
         Returns:
           Loss values per sample.
         """
-        loss: FloatTensor = self.fn(y_true, y_pred, **self._fn_kwargs)
+        loss: FloatTensor = self.fn(y_true, y_pred, y_true, y_pred, **self._fn_kwargs)
         return loss
 
     def get_config(self) -> Dict[str, Any]:

--- a/tensorflow_similarity/losses/pn_loss.py
+++ b/tensorflow_similarity/losses/pn_loss.py
@@ -30,9 +30,12 @@ from .metric_loss import MetricLoss
 
 @tf.keras.utils.register_keras_serializable(package="Similarity")
 @tf.function
-def pn_loss(labels: IntTensor,
-            embeddings: FloatTensor,
+def pn_loss(query_labels: IntTensor,
+            query_embeddings: FloatTensor,
+            key_labels: IntTensor,
+            key_embeddings: FloatTensor,
             distance: Callable,
+            remove_diagonal: bool = True,
             positive_mining_strategy: str = 'hard',
             negative_mining_strategy: str = 'semi-hard',
             soft_margin: bool = False,
@@ -43,12 +46,18 @@ def pn_loss(labels: IntTensor,
 
 
     Args:
-        labels: labels associated with the embed
+        query_labels: labels associated with the query embed.
 
-        embeddings: Embedded examples.
+        query_embeddings: Embedded query examples.
+
+        key_labels: labels associated with the key embed.
+
+        key_embeddings: Embedded key examples.
 
         distance: Which distance function to use to compute the pairwise
         distances between embeddings. Defaults to 'cosine'.
+
+        remove_diagonal: Bool. If True, will set diagonal to False in positive pair mask
 
         positive_mining_strategy: What mining strategy to use to select
         embedding from the same class. Defaults to 'hard'.
@@ -72,13 +81,18 @@ def pn_loss(labels: IntTensor,
     # do not remove this code. It is actually needed for specific situation
     # Reshape label tensor to [batch_size, 1] if not already in that format.
     # labels = tf.reshape(labels, (labels.shape[0], 1))
-    batch_size = tf.size(labels)
+    batch_size = tf.size(query_labels)
 
     # [distances]
-    pairwise_distances = distance(embeddings)
+    pairwise_distances = distance(query_embeddings, key_embeddings)
 
     # [masks]
-    positive_mask, negative_mask = build_masks(labels, batch_size)
+    positive_mask, negative_mask = build_masks(
+        query_labels,
+        key_labels,
+        batch_size=batch_size,
+        remove_diagonal=remove_diagonal,
+    )
 
     # [Positive distance computation]
     pos_distances, pos_idxs = positive_distances(
@@ -93,7 +107,6 @@ def pn_loss(labels: IntTensor,
             pairwise_distances,
             negative_mask,
             positive_mask,
-            batch_size,
     )
 
     # Compute the distance between the pairs of positive and negative examples.

--- a/tensorflow_similarity/losses/softnn_loss.py
+++ b/tensorflow_similarity/losses/softnn_loss.py
@@ -28,26 +28,33 @@ from tensorflow_similarity.types import FloatTensor, IntTensor
 
 @tf.keras.utils.register_keras_serializable(package="Similarity")
 @tf.function
-def soft_nn_loss(labels: IntTensor,
-                 embeddings: FloatTensor,
+def soft_nn_loss(query_labels: IntTensor,
+                 query_embeddings: FloatTensor,
+                 key_labels: IntTensor,
+                 key_embeddings: FloatTensor,
                  distance: Callable,
-                 temperature: float) -> Any:
+                 temperature: float,
+                 remove_diagonal: bool = True) -> Any:
     """Computes the soft nearest neighbors loss.
 
     Args:
-        labels: Labels associated with embeddings.
-        embeddings: Embedded examples.
+        query_labels: labels associated with the query embed.
+        query_embeddings: Embedded query examples.
+        key_labels: labels associated with the key embed.
+        key_embeddings: Embedded key examples.
+        distance: Which distance function to use to compute the pairwise.
         temperature: Controls relative importance given
                         to the pair of points.
+        remove_diagonal: Bool. If True, will set diagonal to False in positive pair mask
 
     Returns:
         loss: loss value for the current batch.
     """
 
-    batch_size = tf.size(labels)
+    batch_size = tf.size(query_labels)
     eps = 1e-9
 
-    pairwise_dist = distance(embeddings)
+    pairwise_dist = distance(query_embeddings, key_embeddings)
     pairwise_dist = pairwise_dist / temperature
     negexpd = tf.math.exp(-pairwise_dist)
 
@@ -57,7 +64,12 @@ def soft_nn_loss(labels: IntTensor,
     negexpd = tf.math.multiply(negexpd, diag_mask)
 
     # creating mask to sample same class neighboorhood
-    pos_mask, _ = build_masks(labels, batch_size)
+    pos_mask, _ = build_masks(
+        query_labels,
+        key_labels,
+        batch_size=batch_size,
+        remove_diagonal=remove_diagonal,
+    )
     pos_mask = tf.cast(pos_mask, dtype=tf.float32)
 
     # all class neighborhood

--- a/tensorflow_similarity/losses/utils.py
+++ b/tensorflow_similarity/losses/utils.py
@@ -54,8 +54,7 @@ def positive_distances(positive_mining_strategy: str,
 def negative_distances(negative_mining_strategy: str,
                        distances: FloatTensor,
                        negative_mask: BoolTensor,
-                       positive_mask: BoolTensor,
-                       batch_size: int) -> Tuple[FloatTensor, FloatTensor]:
+                       positive_mask: BoolTensor) -> Tuple[FloatTensor, FloatTensor]:
     """Negative distance computation.
 
     Args:
@@ -92,7 +91,7 @@ def negative_distances(negative_mining_strategy: str,
 
         # combine with negative mask: keep negative value if greater,
         # zero otherwise
-        empty = tf.zeros((batch_size, batch_size), dtype=tf.bool)
+        empty = tf.zeros_like(greater_distances, dtype=tf.bool)
         semi_hard_mask = tf.where(greater_distances, negative_mask, empty)
 
         # find the  minimal distance between negative labels above threshold

--- a/tensorflow_similarity/training_metrics/distance_metrics.py
+++ b/tensorflow_similarity/training_metrics/distance_metrics.py
@@ -60,11 +60,11 @@ class DistanceMetric(Metric):
     def update_state(self, labels, embeddings, sample_weight):
 
         # [distances]
-        pairwise_distances = self.distance(embeddings)
+        pairwise_distances = self.distance(embeddings, embeddings)
 
         # [mask]
         batch_size = tf.size(labels)
-        positive_mask, negative_mask = build_masks(labels, batch_size)
+        positive_mask, negative_mask = build_masks(labels, labels, batch_size)
 
         if self.anchor == "positive":
             if self.positive_mining_strategy == "hard":

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -41,15 +41,38 @@ def test_inner_product_similarity():
     # pairwise
     a = tf.convert_to_tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
     d = InnerProductSimilarity()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 12
+
+
+def test_inner_product_key():
+    a = tf.convert_to_tensor([
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    b = tf.convert_to_tensor([
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    d = InnerProductSimilarity()
+    vals = d(a, b)
+    expected = tf.constant([
+        [0., 0., 0.],
+        [1., 1., 0.],
+        [1., 2., 3.],
+        [0., 3., 9.]
+    ])
+    tf.assert_equal(vals, expected)
 
 
 def test_inner_product_opposite():
     a = tf.convert_to_tensor([[0.0, 1.0], [1.0, 0.0]])
     d = InnerProductSimilarity()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 2
 
@@ -57,17 +80,40 @@ def test_inner_product_opposite():
 def test_inner_product_vals():
     a = tf.nn.l2_normalize([[0.1, 0.3, 0.2], [0.0, 0.1, 0.5]], axis=-1)
     d = InnerProductSimilarity()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert vals[0][0] == 1
     assert vals[0][1] == 0.68138516
+
+
+def test_cosine_key():
+    a = tf.convert_to_tensor([
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    b = tf.convert_to_tensor([
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    d = CosineDistance()
+    vals = d(a, b)
+    expected = tf.constant([
+        [1., 1., 1.],
+        [0., 0., 1.],
+        [0., 0., 0.],
+        [1., 0., 0.]
+    ])
+    tf.assert_equal(vals, expected)
 
 
 def test_cosine_same():
     # pairwise
     a = tf.convert_to_tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
     d = CosineDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 0
 
@@ -75,7 +121,7 @@ def test_cosine_same():
 def test_cosine_opposite():
     a = tf.convert_to_tensor([[0.0, 1.0], [1.0, 0.0]])
     d = CosineDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 2
 
@@ -83,7 +129,7 @@ def test_cosine_opposite():
 def test_cosine_vals():
     a = tf.nn.l2_normalize([[0.1, 0.3, 0.2], [0.0, 0.1, 0.5]], axis=-1)
     d = CosineDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert vals[0][0] == 0
     assert vals[0][1] == 0.31861484
 
@@ -91,15 +137,35 @@ def test_cosine_vals():
 def test_euclidean():
     a = tf.convert_to_tensor([[0.0, 3.0], [4.0, 0.0]])
     d = EuclideanDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 10
+
+
+def test_euclidean_key():
+    a = tf.convert_to_tensor([
+        [0.0, 1.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+    ])
+    b = tf.convert_to_tensor([
+        [2.0, 1.0],
+        [1.0, 1.0],
+    ])
+    d = EuclideanDistance()
+    vals = d(a, b)
+    expected = tf.constant([
+        [2., 1.],
+        [2., 1.],
+        [1., 0.]
+    ])
+    tf.assert_equal(vals, expected)
 
 
 def test_euclidean_same():
     a = tf.convert_to_tensor([[1.0, 1.0], [1.0, 1.0]])
     d = EuclideanDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 0
 
@@ -107,31 +173,56 @@ def test_euclidean_same():
 def test_euclidean_opposite():
     a = tf.convert_to_tensor([[0.0, 1.0], [0.0, -1.0]])
     d = EuclideanDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 4
 
 
 def test_manhattan():
-    a = tf.convert_to_tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [3.0, 0.0]])
+    a = tf.convert_to_tensor([
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
     d = ManhattanDistance()
-    vals = d(a)
-    expected = tf.constant(
-        [
-            [0.0, 1.0, 2.0, 3.0],
-            [1.0, 0.0, 1.0, 4.0],
-            [2.0, 1.0, 0.0, 3.0],
-            [3.0, 4.0, 3.0, 0.0],
-        ]
-    )
+    vals = d(a, a)
+    expected = tf.constant([
+        [0.0, 1.0, 2.0, 3.0],
+        [1.0, 0.0, 1.0, 4.0],
+        [2.0, 1.0, 0.0, 3.0],
+        [3.0, 4.0, 3.0, 0.0]
+    ])
     assert tf.math.reduce_all(tf.shape(vals) == (4, 4))
     assert tf.reduce_all(tf.math.equal(vals, expected))
 
 
+def test_manhattan_key():
+    a = tf.convert_to_tensor([
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    b = tf.convert_to_tensor([
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [3.0, 0.0]
+    ])
+    d = ManhattanDistance()
+    vals = d(a, b)
+    expected = tf.constant([
+        [1.0, 2.0, 3.0],
+        [0.0, 1.0, 4.0],
+        [1.0, 0.0, 3.0],
+        [4.0, 3.0, 0.0]
+    ])
+    tf.assert_equal(vals, expected)
+
 def test_manhattan_same():
     a = tf.convert_to_tensor([[1.0, 1.0], [1.0, 1.0]])
     d = ManhattanDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 0
 
@@ -139,7 +230,7 @@ def test_manhattan_same():
 def test_manhattan_opposite():
     a = tf.convert_to_tensor([[0.0, 1.0], [0.0, -1.0]])
     d = ManhattanDistance()
-    vals = d(a)
+    vals = d(a, a)
     assert tf.math.reduce_all(tf.shape(vals) == (2, 2))
     assert tf.round(tf.reduce_sum(vals)) == 4
 
@@ -164,7 +255,35 @@ def test_snr_dist():
     snr_pairs = np.array(snr_pairs)
 
     x = tf.convert_to_tensor(x)
-    snr_distances = SNRDistance()(x).numpy()
+    snr_distances = SNRDistance()(x, x).numpy()
+    assert np.all(snr_distances >= 0)
+    diff = snr_distances - snr_pairs
+    assert np.all(np.abs(diff) < 1e-4)
+
+
+def test_snr_dist_key():
+    """
+    Comparing SNRDistance with simple loop based implementation
+    of SNR distance for 2 different embedding tensors.
+    """
+    num_inputs = 3
+    num_inputs2 = 2
+    dims = 5
+    x = np.random.uniform(0, 1, (num_inputs, dims))
+    x2 = np.random.uniform(0, 1, (num_inputs2, dims))
+
+    # Computing SNR distance values using loop
+    snr_pairs = []
+    for i in range(num_inputs):
+        row = []
+        for j in range(num_inputs2):
+            dist = np.var(x[i] - x2[j]) / np.var(x[i])
+            row.append(dist)
+        snr_pairs.append(row)
+    snr_pairs = np.array(snr_pairs)
+
+    x = tf.convert_to_tensor(x)
+    snr_distances = SNRDistance()(x, x2).numpy()
     assert np.all(snr_distances >= 0)
     diff = snr_distances - snr_pairs
     assert np.all(np.abs(diff) < 1e-4)


### PR DESCRIPTION
This PR proposes to have `Distance` take two embedding tensors as input, and the `losses` module to support computing losses for asymmetric and non-square distance matrices.

These changes will accomodate new features such as [Cross-batch-memory (XBM)](https://arxiv.org/pdf/1912.06798.pdf) and will make it easier to close #92 in a new future pull request. Furthermore, these changes will make `Distance` and `losses` support a wider range of usecases, without much added complexity.

The `call` method of `Distance` will now have the following signature:
```python
def call(self, query_embeddings: FloatTensor, key_embeddings: FloatTensor) -> FloatTensor:
    """Compute distance(query_embeddings, key_embeddings)"""
```
instead of:

```python
def call(self, embeddings: FloatTensor) -> FloatTensor:
    """Compute distance(embeddings, embeddings)"""
```

Mathematically, it is quite intuitive and natural for a distance function to take two inputs, so confusion should be
minimal for users when they try to implement custom distances using `Distance`. It will also follow a similar pattern as [Distances](https://kevinmusgrave.github.io/pytorch-metric-learning/distances/#basedistance) in [Pytorch Metric Learning](https://kevinmusgrave.github.io/pytorch-metric-learning)

Right now the self-supervised contrastive losses implemented in `simclr.py`, `barlow.py` and `simsiam.py`
can not make use of any `Distance` implementation to compare the embeddings of two different views.
Since `Distance` is highly integrated into the supervised similarity losses, it would be natural for them to also
be integratable into the self-supervised losses.
For example by using `CosineDistance` in `simsiam.py` instead of re-implementing it on [line 17](https://github.com/tensorflow/similarity/blob/a671b5289b96016f453ef7b1f216d4db009cdc0c/tensorflow_similarity/losses/simsiam.py#L17).

The loss functions in the `losses` module are changed to have the following signature:
```python
def triplet_loss(query_labels: IntTensor,
                 query_embeddings: FloatTensor,
                 key_labels: IntTensor,
                 key_embeddings: FloatTensor,
                 distance: Callable,
                 remove_diagonal: bool = True,
                 #... loss hyperparameters
                 ) -> Any:
```
instead of:

```python
def triplet_loss(labels: IntTensor,
                 embeddings: FloatTensor,
                 distance: Callable,
                 #... loss hyperparameters
                 ) -> Any:
```

This makes it possible to compute the loss between two different embedding tensors each with their own labels.
This will be necessary to support XBM.

The additional input arguments added to `Distance` and to loss functions are required positional arguments.
They could be optional, but from the discussion in #92 it was decided that making them required is less confusing. 

NOTE: This exact PR does not close #92

Please let me know what you think, and any suggested changes are more than welcome!
