### PR TITLE
Added features of SplitValidationLoss callback to EvalCallback

### DIFF
--- a/tensorflow_similarity/utils.py
+++ b/tensorflow_similarity/utils.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 "Various utilities functions for improved quality of life."
 import math
-from typing import Optional, Sequence
-
+from typing import Optional, Sequence, Dict, List
+import numpy as np
 import tensorflow as tf
 
 from tensorflow_similarity.types import BoolTensor
@@ -81,6 +81,22 @@ def unpack_lookup_distances(
     dists: FloatTensor = ragged_dists.to_tensor(default_value=math.inf)
 
     return dists
+
+
+def unpack_results(results: Dict[str, np.ndarray], epoch: int, logs: dict,
+                   tb_writer: tf.summary.SummaryWriter,
+                   name_suffix: Optional[str] = "") -> List[str]:
+    """Updates logs, writes summary, and returns list of strings of
+    evaluation metric"""
+    mstr = []
+    for metric_name, vals in results.items():
+        float_val = vals[0]
+        logs[metric_name] = float_val
+        mstr.append(f"{metric_name}{name_suffix}: {float_val:.4f}")
+        if tb_writer:
+            with tb_writer.as_default():
+                tf.summary.scalar(metric_name, float_val, step=epoch)
+    return mstr
 
 
 def _same_length_rows(x: tf.RaggedTensor) -> BoolTensor:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -248,16 +248,16 @@ def test_split_val_eval_init(tmp_path):
         log_dir.mkdir(parents=True)
 
     callback = EvalCallback(queries=queries,
-                                   query_labels=query_labels,
-                                   targets=targets,
-                                   target_labels=target_labels,
-                                   known_classes=known_classes,
-                                   distance=distance,
-                                   metrics=metrics,
-                                   k=k,
-                                   matcher=matcher,
-                                   distance_thresholds=distance_thresholds,
-                                   tb_logdir=log_dir)
+                            query_labels=query_labels,
+                            targets=targets,
+                            target_labels=target_labels,
+                            known_classes=known_classes,
+                            distance=distance,
+                            metrics=metrics,
+                            k=k,
+                            matcher=matcher,
+                            distance_thresholds=distance_thresholds,
+                            tb_logdir=log_dir)
 
     assert tf.math.reduce_all(callback.targets == targets)
     assert tf.math.reduce_all(callback.target_labels == target_labels)
@@ -288,11 +288,11 @@ def test_split_val_eval_callback(tmp_path):
         log_dir.mkdir(parents=True)
 
     callback = EvalCallback(queries=queries,
-                                   query_labels=query_labels,
-                                   targets=targets,
-                                   target_labels=target_labels,
-                                   known_classes=known_classes,
-                                   tb_logdir=str(log_dir))
+                            query_labels=query_labels,
+                            targets=targets,
+                            target_labels=target_labels,
+                            known_classes=known_classes,
+                            tb_logdir=str(log_dir))
 
     # manually set model ^^
     tf.keras.backend.clear_session()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -23,8 +23,8 @@ def test_eval_init_defaults():
         target_labels=target_labels,
     )
 
-    assert tf.math.reduce_all(callback.queries == queries)
-    assert tf.math.reduce_all(callback.query_labels == query_labels)
+    assert tf.math.reduce_all(callback.queries_known == queries)
+    assert tf.math.reduce_all(callback.query_labels_known == query_labels)
     assert tf.math.reduce_all(callback.targets == targets)
     assert tf.math.reduce_all(callback.target_labels == target_labels)
     assert callback.distance == 'cosine'
@@ -63,8 +63,8 @@ def test_eval_init(tmp_path):
                             distance_thresholds=distance_thresholds,
                             tb_logdir=log_dir)
 
-    assert tf.math.reduce_all(callback.queries == queries)
-    assert tf.math.reduce_all(callback.query_labels == query_labels)
+    assert tf.math.reduce_all(callback.queries_known == queries)
+    assert tf.math.reduce_all(callback.query_labels_known == query_labels)
     assert tf.math.reduce_all(callback.targets == targets)
     assert tf.math.reduce_all(callback.target_labels == target_labels)
     assert callback.distance == 'l2'
@@ -210,6 +210,84 @@ def test_split_val_loss_callback(tmp_path):
         log_dir.mkdir(parents=True)
 
     callback = SplitValidationLoss(queries=queries,
+                                   query_labels=query_labels,
+                                   targets=targets,
+                                   target_labels=target_labels,
+                                   known_classes=known_classes,
+                                   tb_logdir=str(log_dir))
+
+    # manually set model ^^
+    tf.keras.backend.clear_session()
+    inputs = tf.keras.layers.Input(shape=(2,))
+    outputs = tf.keras.layers.Dense(2)(inputs)
+    model = SimilarityModel(inputs, outputs)
+    model.compile('adam', loss='mse', distance='cosine')
+    callback.model = model
+
+    # call the only callback method implemented
+    callback.on_epoch_end(0, {})
+
+def test_split_val_eval_init(tmp_path):
+    queries = tf.constant([[1, 2], [3, 4]])
+    query_labels = tf.constant([1, 2])
+    targets = tf.constant([[1, 2], [3, 4]])
+    target_labels = tf.constant([1, 2])
+    known_classes = tf.constant([1])
+    distance = 'l2'
+    metrics = [Recall()]
+    k = 11
+    matcher = 'majority_vote'
+    distance_thresholds = tf.constant([0.1, 0.2, 0.3])
+    q_known = tf.constant([[1, 2]])
+    q_label_known = tf.constant([1], dtype='int32')
+    q_unknown = tf.constant([[3, 4]])
+    q_label_unknown = tf.constant([2], dtype='int32')
+
+    log_dir = tmp_path / 'sec/'
+    if not log_dir.exists():
+        log_dir.mkdir(parents=True)
+
+    callback = EvalCallback(queries=queries,
+                                   query_labels=query_labels,
+                                   targets=targets,
+                                   target_labels=target_labels,
+                                   known_classes=known_classes,
+                                   distance=distance,
+                                   metrics=metrics,
+                                   k=k,
+                                   matcher=matcher,
+                                   distance_thresholds=distance_thresholds,
+                                   tb_logdir=log_dir)
+
+    assert tf.math.reduce_all(callback.targets == targets)
+    assert tf.math.reduce_all(callback.target_labels == target_labels)
+    assert callback.distance == 'l2'
+    assert isinstance(callback.evaluator, MemoryEvaluator)
+    assert {'recall'} == set([m.name for m in callback.metrics])
+    assert callback.k == 11
+    assert tf.math.reduce_all(
+        callback.distance_thresholds == distance_thresholds)
+    assert callback.matcher == 'majority_vote'
+    assert isinstance(callback.tb_writer, tf.summary.SummaryWriter)
+
+    assert tf.math.reduce_all(callback.queries_known == q_known)
+    assert tf.math.reduce_all(callback.query_labels_known == q_label_known)
+    assert tf.math.reduce_all(callback.queries_unknown == q_unknown)
+    assert tf.math.reduce_all(callback.query_labels_unknown == q_label_unknown)
+
+
+def test_split_val_eval_callback(tmp_path):
+    queries = tf.constant([[1, 2], [1, 2]])
+    query_labels = tf.constant([1, 2])
+    targets = tf.constant([[1, 2], [1, 2]])
+    target_labels = tf.constant([1, 2])
+    known_classes = tf.constant([1])
+
+    log_dir = tmp_path / 'sec/'
+    if not log_dir.exists():
+        log_dir.mkdir(parents=True)
+
+    callback = EvalCallback(queries=queries,
                                    query_labels=query_labels,
                                    targets=targets,
                                    target_labels=target_labels,


### PR DESCRIPTION
Merged SplitValidationLoss into EvalCallback. Closes issue #220 

I have renamed `queries` and `query_labels` as `queries_known` and `queries_labels_known` in EvalCallback for readability. This might be a breaking change.
