### PR TITLE
fix: initiate the _index attribute of the Models to None to correctly raise the errors when missing

### DIFF
--- a/tensorflow_similarity/models/contrastive_model.py
+++ b/tensorflow_similarity/models/contrastive_model.py
@@ -120,6 +120,8 @@ class ContrastiveModel(tf.keras.Model):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        self._index = None
+        
         self.backbone = backbone
         self.projector = projector
         self.predictor = predictor

--- a/tensorflow_similarity/models/similarity_model.py
+++ b/tensorflow_similarity/models/similarity_model.py
@@ -88,6 +88,7 @@ class SimilarityModel(tf.keras.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._index = None
 
     def compile(
         self,


### PR DESCRIPTION
Currently, the Exception of the following snippet is never raised:

```
    if not self._index:
        raise Exception(
            "You need to compile the model with a valid"
            "distance to be able to use the indexing"
        )
```