### PR TITLE
#263 pull float dtype from the model instead of the queries.

### DIFF
--- a/tensorflow_similarity/__init__.py
+++ b/tensorflow_similarity/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '0.16.1'
+__version__ = '0.16.2'
 
 
 from . import algebra  # noqa

--- a/tensorflow_similarity/callbacks.py
+++ b/tensorflow_similarity/callbacks.py
@@ -356,7 +356,7 @@ def _compute_classification_metrics(
         A Python dict mapping the metric name to the copmuted value.
     """
     lookups = model.lookup(queries, k=k, verbose=0)
-    lookup_distances = unpack_lookup_distances(lookups, queries.dtype)
+    lookup_distances = unpack_lookup_distances(lookups, model.dtype)
     lookup_labels = unpack_lookup_labels(lookups, query_labels.dtype)
 
     # TODO(ovallis): Support passing other matchers. Currently we are using


### PR DESCRIPTION
Quick patch to fix casting error in Callback. We had been pulling this type from the queries, but these can be tf.String tensors at that point. We now pull the type from the model. 