### PR TITLE
Minor typo fix in XBM loss

### DIFF
--- a/tensorflow_similarity/losses/xbm_loss.py
+++ b/tensorflow_similarity/losses/xbm_loss.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""VicReg Loss
+"""XBM Loss
     Cross-batch memory for embedding learning.
     https://arxiv.org/abs/1912.06798
 """


### PR DESCRIPTION
Was accidentally titled VicReg
