### PR TITLE
Update .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Since git version 2.23, git-blame has a feature to ignore any commit in this file.
 
 # Migrate code to black + isort
-dc219c04371306b6975e3b8f68815d94d376263d
+2821d07e7248c412384734b1592b94140754897d


### PR DESCRIPTION
Hi @owenvallis I thought the previous commit wouldn't be squashed but because it was we need to update the commit for git ignore to ignore 