### PR TITLE
Fixed import of AUTOTUNE

### DIFF
--- a/tensorflow_similarity/samplers/tfrecords_samplers.py
+++ b/tensorflow_similarity/samplers/tfrecords_samplers.py
@@ -26,7 +26,7 @@ def TFRecordDatasetSampler(
     batch_size: int = 32,
     shards_per_cycle: int = None,
     compression: Optional[str] = None,
-    parallelism: int = tf.data.AUTOTUNE,
+    parallelism: int = tf.data.experimental.AUTOTUNE,
     async_cycle: bool = False,
     prefetch_size: Optional[int] = None,
     shard_suffix: str = "*.tfrec",


### PR DESCRIPTION
I was running the pytest command at the root of the dir and I found an import error of AUTOTUNE. According to the [TensorFlow 2.3 documentation](https://www.tensorflow.org/versions/r2.3/api_docs/python/tf/data/experimental#other_members), AUTOTUNE lies under the tensorflow.data.experimental rather tensorflow.data. This fixes that error.