### PR TITLE
Add MultiShotFileSampler

### DIFF
--- a/tensorflow_similarity/samplers/__init__.py
+++ b/tensorflow_similarity/samplers/__init__.py
@@ -31,6 +31,7 @@ the dataset.
 """
 from .memory_samplers import MultiShotMemorySampler  # noqa
 from .memory_samplers import SingleShotMemorySampler  # noqa
+from .file_samplers import MultiShotFileSampler  # noqa
 from .tfdataset_samplers import TFDatasetMultiShotMemorySampler  # noqa
 from .tfrecords_samplers import TFRecordDatasetSampler  # noqa
 from .utils import select_examples  # noqa

--- a/tensorflow_similarity/samplers/file_samplers.py
+++ b/tensorflow_similarity/samplers/file_samplers.py
@@ -1,0 +1,263 @@
+# Copyright 2021 The TensorFlow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+from collections import defaultdict
+from typing import Optional, Sequence, Set, Tuple, TypeVar, Callable
+
+import numpy as np
+import tensorflow as tf
+from tqdm.auto import tqdm
+
+from tensorflow_similarity.types import FloatTensor, IntTensor
+
+from .samplers import Augmenter, Sampler
+from .utils import select_examples
+
+T = TypeVar("T", FloatTensor, IntTensor)
+
+
+def load_image(
+    path: str,
+    target_size: Optional[Tuple[int, int]] = None
+) -> T:
+    image_string = tf.io.read_file(path)
+    image = tf.image.decode_jpeg(image_string, channels=3)
+    image = tf.image.convert_image_dtype(image, tf.float32)
+    if target_size:
+        image = tf.image.resize(
+            image, target_size, method=tf.image.ResizeMethod.LANCZOS3
+        )
+        image = tf.clip_by_value(image, 0., 1.)
+    return image
+
+
+class MultiShotFileSampler(Sampler):
+    def __init__(
+        self,
+        x,
+        y,
+        classes_per_batch: int = 2,
+        examples_per_class_per_batch: int = 2,
+        steps_per_epoch: int = 1000,
+        class_list: Sequence[int] = None,
+        total_examples_per_class: int = None,
+        augmenter: Optional[Augmenter] = None,
+        warmup: int = -1,
+        load_image_fn: Callable = load_image,
+    ):
+        """Create a Multishot image file sampler that ensures that each batch is
+        well balanced. That is, each batch aims to contain
+        `examples_per_class_per_batch` examples of `classes_per_batch` classes.
+
+        The `batch_size` used during training will be equal to:
+        `classes_per_batch` * `examples_per_class_per_batch` unless an
+        `augmenter` that alters the number of examples returned is used. Then
+        the batch_size is a function of how many augmented examples are
+        returned by the `augmenter`.
+
+
+        Multishot samplers are to be used when you have multiple examples for
+        the same class. If this is not the case, then see the
+        [SingleShotFileSampler()](single_file.md) for using single examples
+        with augmentation.
+
+        File samplers are good for datasets that are stored on disk
+        as several image files.
+
+
+        Args:
+            x: image file paths.
+
+            y: labels.
+
+            classes_per_batch: Numbers of distinct class to include in a
+            single batch
+
+            examples_per_class_per_batch: How many example of each class
+            to use per batch. Defaults to 2.
+
+            steps_per_epoch: How many steps/batches per epoch.
+            Defaults to 1000.
+
+            class_list: Filter the list of examples to only keep those who
+            belong to the supplied class list.
+
+            total_examples_per_class: Restrict the number of examples for EACH
+            class to total_examples_per_class if set. If not set, all the
+            available examples are selected. Defaults to None - no selection.
+
+            augmenter: A function that takes a batch in and return a batch out.
+            Can alters the number of examples returned which in turn change the
+            batch_size used. Defaults to None.
+
+            warmup: Keep track of warmup epochs and let the augmenter knows
+            when the warmup is over by passing along with each batch data a
+            boolean `is_warmup`. See `self._get_examples()` Defaults to 0.
+
+            load_image_fn: A function that takes an image file path and returns
+            the corresponding image tensor. Can resize the image and do other
+            preprocessings. Defaults to `load_image`.
+        """
+
+        super().__init__(
+            classes_per_batch,
+            examples_per_class_per_batch=examples_per_class_per_batch,
+            steps_per_epoch=steps_per_epoch,
+            augmenter=augmenter,
+            warmup=warmup,
+        )
+
+        # precompute information we need
+        if not class_list:
+            self.class_list = list(set([int(e) for e in y]))
+        else:
+            # dedup in case user mess up and cast in case its a tensor
+            self.class_list = list(set([int(c) for c in class_list]))
+
+        if classes_per_batch > len(self.class_list):
+            raise ValueError(
+                "the value of classes_per_batch must be <= to the " "number of existing classes in the dataset"
+            )
+
+        self.load_image_fn = load_image_fn
+
+        # We only want to warn users once per class if we are sampling with
+        # replacement
+        self._small_classes: Set[int] = set()
+
+        # filter
+        x, y = select_examples(
+            x,
+            y,
+            class_list=self.class_list,
+            num_examples_per_class=total_examples_per_class,
+        )
+
+        # assign after potential selection
+        self._x = x
+        self._y = y
+
+        # we need to reindex here  as the numbers of samples might have
+        # changed due to the filtering
+        # In this sampler, contrary to file based one, the pool of examples
+        # wont' change so we can optimize by doing this step in the constructor
+        self.index_per_class = defaultdict(list)
+        cls = [int(c) for c in y]  # need to cast as  tensor lookup are slowww
+        for idx in tqdm(range(len(x)), desc="indexing classes"):
+            cl = cls[idx]
+            self.index_per_class[cl].append(idx)
+
+    def _get_examples(self, batch_id: int, num_classes: int, examples_per_class: int) -> Tuple[FloatTensor, IntTensor]:
+        """Get the set of examples that would be used to create a single batch.
+
+        Notes:
+         - before passing the batch data to TF, the sampler will call the
+           augmenter function (if any) on the returned example.
+
+         - A batch_size = num_classes * examples_per_class
+
+         - This function must be defined in the subclass.
+
+        Args:
+            batch_id: id of the batch in the epoch.
+
+            num_classes: How many class should be present in the examples.
+
+            examples_per_class: How many example per class should be returned.
+
+        Returns:
+            x, y: batch of examples size `num_classes` * `examples_per_class`
+        """
+        # select class at random
+        class_list = random.sample(self.class_list, k=num_classes)
+
+        # get example for each class
+        idxs = []
+        for class_id in class_list:
+            class_idxs = self.index_per_class[class_id]
+            if len(class_idxs) < examples_per_class:
+                if class_id not in self._small_classes:
+                    print(
+                        f"WARNING: Class {class_id} only has {len(class_idxs)} "
+                        "unique examples, but examples_per_class is set to "
+                        f"{examples_per_class}. The current batch will sample from "
+                        "class examples with replacement, but you may want to "
+                        "consider passing an Augmenter function or using the "
+                        "SingleShotFileSampler()."
+                    )
+                    self._small_classes.add(class_id)
+                idxs.extend(random.choices(class_idxs, k=examples_per_class))
+            else:
+                idxs.extend(random.sample(class_idxs, k=examples_per_class))
+
+        _batch_x = []
+        batch_y = []
+        # strip examples if needed. This might happen due to rounding
+        for idx in idxs[: self.batch_size]:
+            _batch_x.append(self._x[idx])
+            batch_y.append(self._y[idx])
+
+        batch_x = []
+        for x in _batch_x:
+            batch_x.append(self.load_image_fn(x))
+        batch_x = tf.stack(batch_x)
+
+        return (
+            batch_x,
+            tf.convert_to_tensor(np.array(batch_y)),
+        )
+
+    def get_slice(self, begin: int = 0, size: int = -1) -> Tuple[FloatTensor, IntTensor]:
+        """Extracts a slice over both the x and y tensors.
+
+        This method extracts a slice of size `size` over the first dimension of
+        both the x and y tensors starting at the index specified by `begin`.
+
+        The value of `begin + size` must be less than `self.num_examples`.
+
+        Args:
+            begin: The starting index.
+
+            size: The size of the slice.
+
+        Returns:
+            A Tuple of FloatTensor and IntTensor
+        """
+        _slice_x: FloatTensor = self._get_slice(self._x, begin, size)
+        slice_y: IntTensor = self._get_slice(self._y, begin, size)
+
+        slice_x = []
+        for x in _slice_x:
+            slice_x.append(self.load_image_fn(x))
+        slice_x = tf.stack(slice_x)
+
+        return slice_x, slice_y
+
+    def _get_slice(self, input_: T, begin: int, size: int) -> T:
+        b = [0] * len(tf.shape(input_))
+        b[0] = begin
+        s = [-1] * len(tf.shape(input_))
+        s[0] = size
+
+        slice_: T = tf.slice(input_, b, s)
+        return slice_
+
+    @property
+    def num_examples(self) -> int:
+        return len(self._x)
+
+    @property
+    def example_shape(self):
+        return self.load_image_fn(self._x[0]).shape

--- a/tensorflow_similarity/samplers/file_samplers.py
+++ b/tensorflow_similarity/samplers/file_samplers.py
@@ -11,19 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-import random
-from collections import defaultdict
-from typing import Optional, Sequence, Set, Tuple, TypeVar, Callable
+from typing import Optional, Sequence, Tuple, TypeVar, Callable
 
-import numpy as np
 import tensorflow as tf
-from tqdm.auto import tqdm
 
 from tensorflow_similarity.types import FloatTensor, IntTensor
 
-from .samplers import Augmenter, Sampler
-from .utils import select_examples
+from .samplers import Augmenter
+from .memory_samplers import MultiShotMemorySampler
 
 T = TypeVar("T", FloatTensor, IntTensor)
 
@@ -43,221 +40,29 @@ def load_image(
     return image
 
 
-class MultiShotFileSampler(Sampler):
+class MultiShotFileSampler(MultiShotMemorySampler):
     def __init__(
         self,
         x,
         y,
+        load_example_fn: Callable = load_image,
         classes_per_batch: int = 2,
         examples_per_class_per_batch: int = 2,
         steps_per_epoch: int = 1000,
-        class_list: Sequence[int] = None,
-        total_examples_per_class: int = None,
-        augmenter: Optional[Augmenter] = None,
+        class_list: Sequence[int] | None = None,
+        total_examples_per_class: int | None = None,
+        augmenter: Augmenter | None = None,
         warmup: int = -1,
-        load_image_fn: Callable = load_image,
     ):
-        """Create a Multishot image file sampler that ensures that each batch is
-        well balanced. That is, each batch aims to contain
-        `examples_per_class_per_batch` examples of `classes_per_batch` classes.
-
-        The `batch_size` used during training will be equal to:
-        `classes_per_batch` * `examples_per_class_per_batch` unless an
-        `augmenter` that alters the number of examples returned is used. Then
-        the batch_size is a function of how many augmented examples are
-        returned by the `augmenter`.
-
-
-        Multishot samplers are to be used when you have multiple examples for
-        the same class. If this is not the case, then see the
-        [SingleShotFileSampler()](single_file.md) for using single examples
-        with augmentation.
-
-        File samplers are good for datasets that are stored on disk
-        as several image files.
-
-
-        Args:
-            x: image file paths.
-
-            y: labels.
-
-            classes_per_batch: Numbers of distinct class to include in a
-            single batch
-
-            examples_per_class_per_batch: How many example of each class
-            to use per batch. Defaults to 2.
-
-            steps_per_epoch: How many steps/batches per epoch.
-            Defaults to 1000.
-
-            class_list: Filter the list of examples to only keep those who
-            belong to the supplied class list.
-
-            total_examples_per_class: Restrict the number of examples for EACH
-            class to total_examples_per_class if set. If not set, all the
-            available examples are selected. Defaults to None - no selection.
-
-            augmenter: A function that takes a batch in and return a batch out.
-            Can alters the number of examples returned which in turn change the
-            batch_size used. Defaults to None.
-
-            warmup: Keep track of warmup epochs and let the augmenter knows
-            when the warmup is over by passing along with each batch data a
-            boolean `is_warmup`. See `self._get_examples()` Defaults to 0.
-
-            load_image_fn: A function that takes an image file path and returns
-            the corresponding image tensor. Can resize the image and do other
-            preprocessings. Defaults to `load_image`.
-        """
-
         super().__init__(
-            classes_per_batch,
+            x,
+            y,
+            load_example_fn=load_example_fn,
+            classes_per_batch=classes_per_batch,
             examples_per_class_per_batch=examples_per_class_per_batch,
             steps_per_epoch=steps_per_epoch,
+            class_list=class_list,
+            total_examples_per_class=total_examples_per_class,
             augmenter=augmenter,
             warmup=warmup,
         )
-
-        # precompute information we need
-        if not class_list:
-            self.class_list = list(set([int(e) for e in y]))
-        else:
-            # dedup in case user mess up and cast in case its a tensor
-            self.class_list = list(set([int(c) for c in class_list]))
-
-        if classes_per_batch > len(self.class_list):
-            raise ValueError(
-                "the value of classes_per_batch must be <= to the " "number of existing classes in the dataset"
-            )
-
-        self.load_image_fn = load_image_fn
-
-        # We only want to warn users once per class if we are sampling with
-        # replacement
-        self._small_classes: Set[int] = set()
-
-        # filter
-        x, y = select_examples(
-            x,
-            y,
-            class_list=self.class_list,
-            num_examples_per_class=total_examples_per_class,
-        )
-
-        # assign after potential selection
-        self._x = x
-        self._y = y
-
-        # we need to reindex here  as the numbers of samples might have
-        # changed due to the filtering
-        # In this sampler, contrary to file based one, the pool of examples
-        # wont' change so we can optimize by doing this step in the constructor
-        self.index_per_class = defaultdict(list)
-        cls = [int(c) for c in y]  # need to cast as  tensor lookup are slowww
-        for idx in tqdm(range(len(x)), desc="indexing classes"):
-            cl = cls[idx]
-            self.index_per_class[cl].append(idx)
-
-    def _get_examples(self, batch_id: int, num_classes: int, examples_per_class: int) -> Tuple[FloatTensor, IntTensor]:
-        """Get the set of examples that would be used to create a single batch.
-
-        Notes:
-         - before passing the batch data to TF, the sampler will call the
-           augmenter function (if any) on the returned example.
-
-         - A batch_size = num_classes * examples_per_class
-
-         - This function must be defined in the subclass.
-
-        Args:
-            batch_id: id of the batch in the epoch.
-
-            num_classes: How many class should be present in the examples.
-
-            examples_per_class: How many example per class should be returned.
-
-        Returns:
-            x, y: batch of examples size `num_classes` * `examples_per_class`
-        """
-        # select class at random
-        class_list = random.sample(self.class_list, k=num_classes)
-
-        # get example for each class
-        idxs = []
-        for class_id in class_list:
-            class_idxs = self.index_per_class[class_id]
-            if len(class_idxs) < examples_per_class:
-                if class_id not in self._small_classes:
-                    print(
-                        f"WARNING: Class {class_id} only has {len(class_idxs)} "
-                        "unique examples, but examples_per_class is set to "
-                        f"{examples_per_class}. The current batch will sample from "
-                        "class examples with replacement, but you may want to "
-                        "consider passing an Augmenter function or using the "
-                        "SingleShotFileSampler()."
-                    )
-                    self._small_classes.add(class_id)
-                idxs.extend(random.choices(class_idxs, k=examples_per_class))
-            else:
-                idxs.extend(random.sample(class_idxs, k=examples_per_class))
-
-        _batch_x = []
-        batch_y = []
-        # strip examples if needed. This might happen due to rounding
-        for idx in idxs[: self.batch_size]:
-            _batch_x.append(self._x[idx])
-            batch_y.append(self._y[idx])
-
-        batch_x = []
-        for x in _batch_x:
-            batch_x.append(self.load_image_fn(x))
-        batch_x = tf.stack(batch_x)
-
-        return (
-            batch_x,
-            tf.convert_to_tensor(np.array(batch_y)),
-        )
-
-    def get_slice(self, begin: int = 0, size: int = -1) -> Tuple[FloatTensor, IntTensor]:
-        """Extracts a slice over both the x and y tensors.
-
-        This method extracts a slice of size `size` over the first dimension of
-        both the x and y tensors starting at the index specified by `begin`.
-
-        The value of `begin + size` must be less than `self.num_examples`.
-
-        Args:
-            begin: The starting index.
-
-            size: The size of the slice.
-
-        Returns:
-            A Tuple of FloatTensor and IntTensor
-        """
-        _slice_x: FloatTensor = self._get_slice(self._x, begin, size)
-        slice_y: IntTensor = self._get_slice(self._y, begin, size)
-
-        slice_x = []
-        for x in _slice_x:
-            slice_x.append(self.load_image_fn(x))
-        slice_x = tf.stack(slice_x)
-
-        return slice_x, slice_y
-
-    def _get_slice(self, input_: T, begin: int, size: int) -> T:
-        b = [0] * len(tf.shape(input_))
-        b[0] = begin
-        s = [-1] * len(tf.shape(input_))
-        s[0] = size
-
-        slice_: T = tf.slice(input_, b, s)
-        return slice_
-
-    @property
-    def num_examples(self) -> int:
-        return len(self._x)
-
-    @property
-    def example_shape(self):
-        return self.load_image_fn(self._x[0]).shape

--- a/tests/samplers/test_file_samplers.py
+++ b/tests/samplers/test_file_samplers.py
@@ -140,7 +140,7 @@ def test_small_class_size(capsys):
         "examples_per_class is set to 3. The current batch will sample "
         "from class examples with replacement, but you may want to "
         "consider passing an Augmenter function or using the "
-        "SingleShotFileSampler()."
+        "SingleShotMemorySampler()."
     )
 
     match = re.search(expected_msg, captured.out)

--- a/tests/samplers/test_file_samplers.py
+++ b/tests/samplers/test_file_samplers.py
@@ -1,0 +1,158 @@
+import os
+import re
+import tempfile
+
+import numpy as np
+
+import pytest
+import tensorflow as tf
+
+from tensorflow_similarity.samplers import MultiShotFileSampler
+
+
+def _create_random_image(filename, size=(32, 32)):
+    filepath = os.path.join(tempfile.gettempdir(), filename)
+    image = np.random.random(size + (3,)).astype(np.float32)
+    tf.keras.utils.save_img(filepath, image)
+    return filepath
+
+
+@pytest.mark.parametrize("example_per_class", [2, 20])
+def test_multi_shot_file_sampler(example_per_class):
+    """Test MultiShotFileSampler with various sizes.
+
+    Users may sample with replacement when creating batches, so check that we
+    can handle when elements per class is either less than or greater than the
+    total count of elements in the class.
+    """
+    filenames = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg', '6.jpg']
+    filepaths = [
+        _create_random_image(filename) for filename in filenames
+    ]
+    images = [
+        np.array(tf.keras.utils.load_img(path), dtype=np.float32) / 255
+        for path in filepaths
+    ]
+
+    y = tf.constant([1, 2, 3, 1, 2, 3])
+    x = tf.constant(filepaths)
+    class_per_batch = 2
+    batch_size = example_per_class * class_per_batch
+
+    fs_sampler = MultiShotFileSampler(
+        x=x,
+        y=y,
+        classes_per_batch=class_per_batch,
+        examples_per_class_per_batch=example_per_class,
+    )  # noqa
+
+    batch_x, batch_y = fs_sampler.generate_batch(batch_id=606)
+
+    assert len(batch_y) == batch_size
+    assert len(batch_x) == batch_size
+    num_classes, _ = tf.unique(batch_y)
+    assert len(num_classes) == class_per_batch
+
+    for x, y in zip(batch_x, batch_y):
+        if y == 1:
+            assert (
+                np.isclose(x.numpy(), images[0], atol=.1).all() or
+                np.isclose(x.numpy(), images[3], atol=.1).all()
+            )
+        elif y == 2:
+            assert (
+                np.isclose(x.numpy(), images[1], atol=.1).all() or
+                np.isclose(x.numpy(), images[4], atol=.1).all()
+            )
+        elif y == 3:
+            assert (
+                np.isclose(x.numpy(), images[2], atol=.1).all() or
+                np.isclose(x.numpy(), images[5], atol=.1).all()
+            )
+
+
+def test_msfs_get_slice():
+    """Test the multi shot file sampler get_slice method."""
+    filenames = ['1.jpg', '2.jpg', '3.jpg', '4.jpg']
+    filepaths = [
+        _create_random_image(filename) for filename in filenames
+    ]
+    images = [
+        np.array(tf.keras.utils.load_img(path), dtype=np.float32) / 255
+        for path in filepaths
+    ]
+
+    y = tf.constant(range(4))
+    x = tf.constant(filepaths)
+
+    fs_sampler = MultiShotFileSampler(x=x, y=y)
+    # x and y are randomly shuffled so we fix the values here.
+    fs_sampler._x = x
+    fs_sampler._y = y
+    slice_x, slice_y = fs_sampler.get_slice(1, 2)
+
+    assert slice_x.shape == (2, 32, 32, 3)
+    assert slice_y.shape == (2,)
+
+    assert np.isclose(slice_x[0], images[1], atol=.1).all()
+    assert np.isclose(slice_x[1], images[2], atol=.1).all()
+
+    assert slice_y[0] == 1
+    assert slice_y[1] == 2
+
+
+def test_msms_properties():
+    """Test the multi shot file sampler num_examples and shape"""
+    filenames = ['1.jpg', '2.jpg', '3.jpg', '4.jpg']
+    filepaths = [
+        _create_random_image(filename, (128, 96)) for filename in filenames
+    ]
+    y = tf.constant(range(4))
+    x = tf.constant(filepaths)
+
+    fs_sampler = MultiShotFileSampler(x=x, y=y)
+
+    assert fs_sampler.num_examples == 4
+    assert fs_sampler.example_shape == (128, 96, 3)
+
+
+def test_small_class_size(capsys):
+    """Test examples_per_class is > the number of class examples."""
+    filenames = ['1.jpg', '2.jpg', '3.jpg', '4.jpg']
+    filepaths = [
+        _create_random_image(filename) for filename in filenames
+    ]
+
+    y = tf.constant([1, 1, 1, 2])
+    x = tf.constant(filepaths)
+
+    fs_sampler = MultiShotFileSampler(x=x, y=y, classes_per_batch=2, examples_per_class_per_batch=3)
+
+    _, batch_y = fs_sampler.generate_batch(0)
+
+    y, _, class_counts = tf.unique_with_counts(batch_y)
+    assert tf.math.reduce_all(tf.sort(y) == tf.constant([1, 2]))
+    assert tf.math.reduce_all(class_counts == tf.constant([3, 3]))
+
+    captured = capsys.readouterr()
+    expected_msg = (
+        "WARNING: Class 2 only has 1 unique examples, but "
+        "examples_per_class is set to 3. The current batch will sample "
+        "from class examples with replacement, but you may want to "
+        "consider passing an Augmenter function or using the "
+        "SingleShotFileSampler()."
+    )
+
+    match = re.search(expected_msg, captured.out)
+    assert bool(match)
+
+    _, batch_y = fs_sampler.generate_batch(0)
+
+    y, _, class_counts = tf.unique_with_counts(batch_y)
+    assert tf.math.reduce_all(tf.sort(y) == tf.constant([1, 2]))
+    assert tf.math.reduce_all(class_counts == tf.constant([3, 3]))
+
+    # Subsequent batch should produce the sampler warning.
+    captured = capsys.readouterr()
+    match = re.search(expected_msg, captured.out)
+    assert not bool(match)


### PR DESCRIPTION
The `MultiShotFileSampler` is a sampler class for reading data from image files stored on the disc. It is quite similar to the `MultiShotMemorySampler`. However, `MultiShotMemorySampler` reads data from an array in the memory, while `MultiShotFileSampler` loads image files from the disc using their corresponding file address. Note that the `x` argument in the class is filled with the file path of the images.

This feature is useful when our dataset is available as multiple images stored on the disk and we don't want to get into trouble of creating *TFRecords*.