### PR TITLE
Add batch_compute_gradient_portion

### DIFF
--- a/tensorflow_similarity/models/similarity_model.py
+++ b/tensorflow_similarity/models/similarity_model.py
@@ -87,7 +87,33 @@ class SimilarityModel(tf.keras.Model):
     """
 
     def __init__(self, *args, **kwargs):
+        self.batch_compute_gradient_portion = float(kwargs.pop('batch_compute_gradient_portion', 1))
+        assert 0. < self.batch_compute_gradient_portion <= 1.
+
         super().__init__(*args, **kwargs)
+
+    def train_step(self, data):
+        x, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
+
+        l = tf.cast(tf.shape(x)[0], tf.float32)
+        k = tf.cast(self.batch_compute_gradient_portion * l, tf.int32)
+
+        # Run forward pass.
+        y_pred_without_gradient = self(x[k:], training=True)
+
+        with tf.GradientTape() as tape:
+            y_pred_with_gradient = self(x[:k], training=True)
+
+            y_pred = tf.concat([y_pred_with_gradient, y_pred_without_gradient], axis=0)
+
+            loss = self.compute_loss(x, y, y_pred, sample_weight)
+
+        self._validate_target_and_loss(y, loss)
+
+        # Run backwards pass.
+        self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
+
+        return self.compute_metrics(x, y, y_pred, sample_weight)
 
     def compile(
         self,


### PR DESCRIPTION
In the `train_step` method of the `Model` class, all samples in the batch are used for updating the network weights. In many problems, this is the correct and common way to update weights. However, in some situations, there are other ways for updating network weights. Sometimes, we can compute loss using all samples in the batch but update the network weights using only a subset of that batch. This is useful when we need to have a large batch but the memory limits don't allow us to compute the gradients for all samples. Hence, a solution is to compute the loss value with all batch samples, and then compute the gradients and update network weights via a subset of those samples. In most problems, this is not meaningful, but in Metric Learning and similar problems, it is quite useful.

For example, consider we are using the `MultiSimilarityLoss` in [this example](https://keras.io/examples/vision/metric_learning_tf_similarity). In this loss function, each batch contains **K** samples from **C** classes. The purpose of `MultiSimilarityLoss` consists in computing loss in a way that the **K** samples belonging to a class get close in the feature space, while at the same time these **K** samples get distant from other classes' samples in that batch. This loss function needs a large batch to perform satisfactorily. However, computing the gradients for all samples in a large batch wouldn't fit in memory. A simple solution, as explained, is computing gradients and updating network weights for only **m** classes from those **C** classes in the batch. Although the loss value is calculated based on all samples in the batch, it is possible to update weights based on a portion of that batch.

I've tested the proposed implementation in an enterprise project for a company I work for, and it's been successful. It remarkably helps to prevent overfitting. I've tested multiple scenarios in which the batch size was kept constant, but the `batch_compute_gradient_portion` value changed from 0.25 to 1. The models trained with `batch_compute_gradient_portion < 1` were clearly less influenced by overfitting. Their generalization ability in predicting completely new samples with different distributions was significantly higher.